### PR TITLE
update ingress for traefik 2

### DIFF
--- a/deployment/base/ingress.yaml
+++ b/deployment/base/ingress.yaml
@@ -1,15 +1,16 @@
-apiVersion: extensions/v1beta1
-kind: Ingress
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
 metadata:
-  name: central-viewer-ingress
   annotations:
     kubernetes.io/ingress.class: traefik
-    traefik.ingress.kubernetes.io/preserve-host: "true"
+  name: central-viewer-ingress
 spec:
-  rules:
-  - http:
-      paths:
-      - backend:
-          serviceName: central-viewer
-          servicePort: 80
-        path: /
+  entryPoints:
+  - http
+  routes:
+  - kind: Rule
+    match: PathPrefix(`/`)
+    services:
+    - kind: Service
+      name: central-viewer
+      port: 80


### PR DESCRIPTION
Updates the Ingresses to IngressRoutes, as they are required by Traefik 2

Linked to kadaster-labs/sensrnet-ops#20