### PR TITLE
show device height from location_object WFS info

### DIFF
--- a/src/app/components/modal/modal.component.ts
+++ b/src/app/components/modal/modal.component.ts
@@ -6,6 +6,7 @@ import { HTTPService } from '../../services/http.service';
 
 import { Datastream } from '../../model/datastream';
 import { DeviceDTO } from '../../model/device';
+import { DeviceLocation } from '../../model/deviceLocation';
 import { Sensor } from '../../model/sensor';
 import { LegalEntity } from '../../model/legalEntity';
 
@@ -58,6 +59,10 @@ export class ModalComponent implements DoCheck {
 
   public getSensors(device: DeviceDTO): Sensor[] {
     return device.sensors ? JSON.parse(device.sensors) : [];
+  }
+
+  public getLocation(device: DeviceDTO): DeviceLocation {
+    return JSON.parse(device.location_object);
   }
 
   public getLegalEntities(device: DeviceDTO): void {

--- a/src/app/components/modal/modal.html
+++ b/src/app/components/modal/modal.html
@@ -153,7 +153,8 @@
         </div>
     </div>
     <!-- Location -->
-    <table *ngIf="selectedNavIndex === 4" class="table table-sm table-striped mb-0">
+    <table *ngIf="selectedNavIndex === 4 && getLocation(devices[selectedDeviceIndex]) as location"
+        class="table table-sm table-striped mb-0">
         <caption class="sr-only sr-only-focusable" i18n>Sensor details</caption>
         <thead class="sr-only sr-only-focusable">
             <tr>
@@ -164,15 +165,16 @@
         <tbody>
             <tr>
                 <td><strong>Longitude</strong></td>
-                <td>{{ devices[selectedDeviceIndex].location[0] }}</td>
+                <!-- show with 3 decimals minimum, 6 maximum -->
+                <td>{{ location.coordinates[0] | number: '1.3-6' }}</td>
             </tr>
             <tr>
                 <td><strong>Latitude</strong></td>
-                <td>{{ devices[selectedDeviceIndex].location[1] }}</td>
+                <td>{{ location.coordinates[1] | number: '1.3-6' }}</td>
             </tr>
             <tr>
                 <td><strong>Height</strong></td>
-                <td>{{ devices[selectedDeviceIndex].location[2] }}</td>
+                <td>{{ location.coordinates[2] | number: '1.0-2' }} meter</td>
             </tr>
         </tbody>
     </table>

--- a/src/app/components/modal/modal.html
+++ b/src/app/components/modal/modal.html
@@ -172,7 +172,7 @@
                 <td><strong>Latitude</strong></td>
                 <td>{{ location.coordinates[1] | number: '1.3-6' }}</td>
             </tr>
-            <tr>
+            <tr *ngIf="location.coordinates[2]">
                 <td><strong>Height</strong></td>
                 <td>{{ location.coordinates[2] | number: '1.0-2' }} meter</td>
             </tr>

--- a/src/app/model/device.ts
+++ b/src/app/model/device.ts
@@ -1,4 +1,4 @@
-import { DeviceLocation } from './location';
+import { DeviceLocation } from './deviceLocation';
 import { Sensor } from './sensor';
 import { Datastream } from './datastream';
 
@@ -16,17 +16,17 @@ interface BaseDevice {
 
   category: Category;
   connectivity?: string;
-
-  location: DeviceLocation;
 }
 
 export interface Device extends BaseDevice {
   dataStreams?: Datastream[];
   sensors?: Sensor[];
+  location_object: DeviceLocation;
 }
 
 // Device as returned by GeoServer. It stringifies the nested objects.
-export interface DeviceDTO extends BaseDevice{
+export interface DeviceDTO extends BaseDevice {
   dataStreams?: string;
   sensors?: string;
+  location_object: string;
 }

--- a/src/app/model/deviceLocation.ts
+++ b/src/app/model/deviceLocation.ts
@@ -1,6 +1,5 @@
 export interface DeviceLocation {
   type: 'Point';
-  /** [latitude, longitude, height] */
+  /** [longitude, latitude, height] */
   coordinates: [number, number, number];
-  baseObjectId: string;
 }


### PR DESCRIPTION
GeoServers sends additional location information in the WFS response. Parse this object and show the location data from there

Links to https://github.com/kadaster-labs/sensrnet-central-viewer-geoserver/pull/5
Closes https://github.com/kadaster-labs/sensrnet-central-viewer/issues/14