### PR TITLE
load observation goals from backend on device select

### DIFF
--- a/src/app/components/modal/modal.html
+++ b/src/app/components/modal/modal.html
@@ -151,6 +151,34 @@
                                 readonly target="_blank">{{ datastream.dataLink }}</a>
                         </div>
                     </div>
+                    <table *ngFor="let observationGoalId of datastream.observationGoalIds"
+                           class="table table-sm table-striped mt-5">
+                        <caption i18n>Legal ground</caption>
+                        <thead class="sr-only sr-only-focusable">
+                        <tr>
+                            <th scope="col" i18n>Attribute</th>
+                            <th scope="col" i18n>Value</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><strong>Name</strong></td>
+                                <td>{{ observationGoalsMap.get(observationGoalId).name }}</td>
+                            </tr>
+                            <tr>
+                                <td><strong>Description</strong></td>
+                                <td>{{ observationGoalsMap.get(observationGoalId).description }}</td>
+                            </tr>
+                            <tr *ngIf="observationGoalsMap.get(observationGoalId).legalGround">
+                                <td><strong>legalGround</strong></td>
+                                <td>{{ observationGoalsMap.get(observationGoalId).legalGround }}</td>
+                            </tr>
+                            <tr *ngIf="observationGoalsMap.get(observationGoalId).legalGroundLink">
+                                <td><strong>legalGroundLink</strong></td>
+                                <td>{{ observationGoalsMap.get(observationGoalId).legalGroundLink }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>

--- a/src/app/model/datastream.ts
+++ b/src/app/model/datastream.ts
@@ -28,5 +28,5 @@ export interface Datastream {
   documentation?: string;
   dataLink?: string;
 
-  observationGoals?: ObservationGoal[];
+  observationGoalIds?: ObservationGoal['_id'];
 }

--- a/src/app/services/http.service.ts
+++ b/src/app/services/http.service.ts
@@ -5,6 +5,7 @@ import { environment } from '../../environments/environment';
 import { LegalEntity } from '../model/legalEntity';
 import { Observable, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
+import { ObservationGoal } from '../model/observationGoal';
 
 @Injectable({ providedIn: 'root' })
 export class HTTPService {
@@ -23,6 +24,15 @@ export class HTTPService {
     return this.http.get<LegalEntity[]>(`${environment.apiUrl}/legalentities`, options)
       .pipe(
         catchError(this.handleError<LegalEntity[]>([]))
+      );
+  }
+
+  public getObservationGoals(id: ObservationGoal['_id']): Observable<ObservationGoal> {
+    const url = `${environment.apiUrl}/observationgoal/${id}`;
+
+    return this.http.get<ObservationGoal>(url)
+      .pipe(
+        catchError(this.handleError<ObservationGoal>(undefined))
       );
   }
 


### PR DESCRIPTION
Add observation goals to datastream info. As it is not included in WFS response, get these details separately from backend, simalr to legal entity info