### PR TITLE
Central viewer under some path

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,12 +17,28 @@ replace_geoserver_env() {
   done
 }
 
+replace_base_href() {
+  # Strip leading and trailing '/'s, if present
+  BASE=$(echo $BASE_HREF | sed 's/^\///;s/\/$//')
+
+  for dir in /usr/share/nginx/html/*/
+  do
+    sed -i "s@<base href=\"/@<base href=\"/${BASE}/@" ${dir}index.html
+  done
+
+  sed -i "s@# rewrite ^/BASE_HREF(/.*)$ \$1 last;@rewrite ^/${BASE}(/.*)$ \$1 last;@" /etc/nginx/conf.d/default.conf
+}
+
 if [[ ! -z "$API_URL" ]]; then
   replace_api_env
 fi
 
 if [[ ! -z "$GEOSERVER_URL" ]]; then
   replace_geoserver_env
+fi
+
+if [ ! -z "$BASE_HREF" ] && [ ! $BASE_HREF = '/' ]; then
+  replace_base_href
 fi
 
 if [ "$1" = "run" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ replace_api_env() {
   # each language has its own subfolder, having its own env.js
   for dir in /usr/share/nginx/html/*/
   do
-    sed -i "s@window.__env.apiUrl = 'api'@window.__env.apiUrl = '${API_URL}'@" ${dir}env.js
+    sed -i "s@window.__env.apiUrl = '/api'@window.__env.apiUrl = '${API_URL}'@" ${dir}env.js
   done
 }
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -18,7 +18,7 @@ add_header X-Frame-Options SAMEORIGIN;
 add_header X-Content-Type-Options nosniff;
 
 # This header enables the Cross-site scripting (XSS) filter built into most recent web browsers.
-# It's usually enabled by default anyway, so the role of this header is to re-enable the filter for 
+# It's usually enabled by default anyway, so the role of this header is to re-enable the filter for
 # this particular website if it was disabled by the user.
 # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
 add_header X-XSS-Protection "1; mode=block";
@@ -47,6 +47,9 @@ server {
   gzip_proxied      expired no-cache no-store private auth;
   gzip_types        text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
   gzip_comp_level   9;
+
+  # Replace BASE_HREF with desired value when running app under some path
+  # rewrite ^/BASE_HREF(/.*)$ $1 last;
 
   location /nl/ {
     rewrite ^/nl/(.*)$ /$1 last;

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -84,7 +84,7 @@ export class MapComponent implements OnInit, OnDestroy {
       }), new Style({
         image: new Icon({
           scale: 0.25,
-          src: `/assets/icons/${item}_op.png`
+          src: `assets/icons/${item}_op.png`
         })
       })];
 

--- a/src/env.js
+++ b/src/env.js
@@ -2,6 +2,6 @@
   window.__env = window.__env || {};
   // these placeholders are actually used to find and replace to set environment variables.
   // DO NOT CHANGE!!
-  window.__env.apiUrl = 'api';
+  window.__env.apiUrl = '/api';
   window.__env.geoserverUrl = '/geoserver/wfs';
 }(this));

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
-  apiUrl: 'api',
+  apiUrl: '/api',
   production: true,
 };


### PR DESCRIPTION
Expanded the entrypoint and Nginx config to allow us to set a BASE_HREF dynamically. This way, it can run under some path, i.e. demo.sensorenregister.nl/viewer/, without needing some manual adjustments. These manual steps are documented here (https://github.com/kadaster-labs/sensrnet-secrets/blob/main/worklog_prod.sh#L127) and been integrated in this PR 

Links to https://github.com/kadaster-labs/sensrnet-central-viewer/issues/49