### PR TITLE
build: add Trivy to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  build-node:
     runs-on: ubuntu-latest
 
     steps:
@@ -34,3 +34,23 @@ jobs:
         run: npm run build
       - name: Run test
         run: npm run test
+
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build image from Dockerfile
+        run: |
+          docker build -t sensrnetnl/central-viewer:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'sensrnetnl/central-viewer:${{ github.sha }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN npm run build
 
 
 # Second Stage : Setup command to serve the app using NGinx
-FROM nginx:1.21.1-alpine
+FROM nginx:1.21.6-alpine
 
 COPY VERSION .
 COPY ./entrypoint.sh ./entrypoint.sh


### PR DESCRIPTION
- Let Trivy scan the Docker Image for High and Critical vulnerabilities. The pipeline will fail if problems are found.
- Update base image to latest version

Links to https://github.com/kadaster-labs/sensrnet-ops/issues/46